### PR TITLE
docs: Uprev to 6.x.x

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -124,13 +124,13 @@
 
                     <li class="nav-item dropdown">
                         <button type="button" class="btn btn-link nav-link py-2 px-0 px-lg-2 dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false" data-bs-display="static">
-                            <span class="d-lg-none" aria-hidden="true">{{ page.title }}</span><span class="visually-hidden">Bootstrap&nbsp;</span> v5.1.x <span class="visually-hidden">(switch to other versions)</span>
+                            <span class="d-lg-none" aria-hidden="true">{{ page.title }}</span><span class="visually-hidden">Bootstrap&nbsp;</span> v6.x.x <span class="visually-hidden">(switch to other versions)</span>
                         </button>
                         <ul class="dropdown-menu dropdown-menu-end">
-                            <li><h6 class="dropdown-header">v5 releases</h6></li>
+                            <li><h6 class="dropdown-header">v6 Releases</h6></li>
                             <li>
                                 <a class="dropdown-item d-flex align-items-center justify-content-between active" aria-current="true" href="/">
-                                    Latest (5.1.x)
+                                    Latest (6.x.x)
                                     <i class="bi bis bi-check2 ms-auto"></i>
                                 </a>
                             </li>


### PR DESCRIPTION
- There‘s no need to keep a seperate 5.x.x version
- avoid confusion